### PR TITLE
Optimize save tracks worker

### DIFF
--- a/db/migrate/20200107022853_add_unique_index_to_streams.rb
+++ b/db/migrate/20200107022853_add_unique_index_to_streams.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToStreams < ActiveRecord::Migration[5.2]
+  def change
+    add_index :streams, [:user_id, :track_id, :played_at], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_29_033453) do
+ActiveRecord::Schema.define(version: 2020_01_07_022853) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,6 +83,7 @@ ActiveRecord::Schema.define(version: 2019_12_29_033453) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["track_id"], name: "index_streams_on_track_id"
+    t.index ["user_id", "track_id", "played_at"], name: "index_streams_on_user_id_and_track_id_and_played_at", unique: true
     t.index ["user_id"], name: "index_streams_on_user_id"
   end
 


### PR DESCRIPTION
This does some hot path optimizations. First, we do the set intersection to find missing spotify tracks in the database itself. Second, we remove some duplicate selects. 

Finally, we perform the (presumed) hot path of adding new `Stream`s using a bulk insert rather than doing a bunch of separate selects and inserts. Feel free to skip the second commit if you don't want to futz with it. It's hard for me to tell from Skylight whether this is actually a hot area or not.

**Important note** I have not tested any of this beyond basic syntax and functional checks within IRB/psql. I don't have any data to test against and there aren't any automated tests. Please please please hit this in a console before deploying.