### PR TITLE
Removes CoffeeScript gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,8 +40,6 @@ gem 'httparty'
 gem "colorize"          # ability to colorize output strings
 gem "skylight"
 
-# Use CoffeeScript for .coffee assets and views
-gem 'coffee-rails', '~> 4.2'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,13 +106,6 @@ GEM
     coderay (1.1.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    coffee-rails (4.2.2)
-      coffee-script (>= 2.2.0)
-      railties (>= 4.0.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     colorize (0.8.1)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
@@ -373,7 +366,6 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   chromedriver-helper
-  coffee-rails (~> 4.2)
   colorize
   dalli
   devise


### PR DESCRIPTION
It doesn't seem like Plylst is using CoffeeScript anywhere in the application. Hence, I think dropping it from dependencies would be a good call. 