### PR TITLE
Add ScoutAPM. Tell Puma to pre-load classes to save memory usage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,9 @@ gem 'jbuilder', '~> 2.5'
 
 gem 'dalli'
 
+# Add Scout for APM support
+gem 'scout_apm'
+
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
       rake (>= 10.4, < 14.0)
     archive-zip (0.12.0)
       io-like (~> 0.3.0)
+    ast (2.4.0)
     autoprefixer-rails (9.7.6)
       execjs
     axiom-types (0.1.1)
@@ -225,6 +226,8 @@ GEM
     omniauth-spotify (0.0.13)
       omniauth-oauth2 (~> 1.1)
     orm_adapter (0.5.0)
+    parser (2.7.1.3)
+      ast (~> 2.4.0)
     pg (1.2.3)
     popper_js (1.16.0)
     public_suffix (3.1.1)
@@ -300,6 +303,8 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    scout_apm (2.6.7)
+      parser
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -414,6 +419,7 @@ DEPENDENCIES
   rails (~> 6.0)
   rspotify!
   sass-rails (~> 5.0)
+  scout_apm
   selenium-webdriver
   sentry-raven
   sidekiq

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -32,7 +32,7 @@ workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
 #
-# preload_app!
+preload_app!
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
I added a ScoutAPM key to the environment group already. I couldn't quickly figure out how to do Datadog, but it appears that Scout should provide similar machinery to debug slow/n+1 queries