### PR TITLE
Update Puma dependency to prevent failed gem installation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,7 @@ GEM
     pg (1.2.3)
     popper_js (1.16.0)
     public_suffix (3.1.1)
-    puma (4.3.5)
+    puma (4.3.7)
       nio4r (~> 2.0)
     puma_worker_killer (0.1.1)
       get_process_mem (~> 0.2)


### PR DESCRIPTION
Puma 4.3.5 fails with:

```
plylst master % gem install puma -v '4.3.5'
Building native extensions. This could take a while...
ERROR:  Error installing puma:
	ERROR: Failed to build gem native extension.

    current directory: /Users/andyw8/.gem/ruby/2.7.0/gems/puma-4.3.5/ext/puma_http11
/opt/rubies/2.7.0/bin/ruby -I /opt/rubies/2.7.0/lib/ruby/2.7.0 -r ./siteconf20210313-16050-1tloy2v.rb extconf.rb
checking for BIO_read() in -lcrypto... yes
checking for SSL_CTX_new() in -lssl... yes
checking for openssl/bio.h... yes
checking for DTLS_method() in openssl/ssl.h... yes
checking for TLS_server_method() in openssl/ssl.h... yes
checking for SSL_CTX_set_min_proto_version in openssl/ssl.h... yes
creating Makefile

current directory: /Users/andyw8/.gem/ruby/2.7.0/gems/puma-4.3.5/ext/puma_http11
make "DESTDIR=" clean

current directory: /Users/andyw8/.gem/ruby/2.7.0/gems/puma-4.3.5/ext/puma_http11
make "DESTDIR="
compiling http11_parser.c
ext/puma_http11/http11_parser.c:44:18: warning: unused variable 'puma_parser_en_main' [-Wunused-const-variable]
static const int puma_parser_en_main = 1;
                 ^
1 warning generated.
compiling io_buffer.c
compiling mini_ssl.c
mini_ssl.c:145:7: warning: unused variable 'min' [-Wunused-variable]
  int min, ssl_options;
      ^
mini_ssl.c:299:40: warning: function 'raise_error' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
void raise_error(SSL* ssl, int result) {
                                       ^
2 warnings generated.
compiling puma_http11.c
puma_http11.c:203:22: error: implicitly declaring library function 'isspace' with type 'int (int)' [-Werror,-Wimplicit-function-declaration]
  while (vlen > 0 && isspace(value[vlen - 1])) vlen--;
                     ^
puma_http11.c:203:22: note: include the header <ctype.h> or explicitly provide a declaration for 'isspace'
1 error generated.
make: *** [puma_http11.o] Error 1

make failed, exit code 2

Gem files will remain installed in /Users/andyw8/.gem/ruby/2.7.0/gems/puma-4.3.5 for inspection.
Results logged to /Users/andyw8/.gem/ruby/2.7.0/extensions/x86_64-darwin-19/2.7.0-static/puma-4.3.5/gem_make.out
```

This is reported as fixed in 4.3.6: https://github.com/puma/puma/issues/2342

I've picked 4.3.7 as that's latest 4.x release. I haven't looked in to what's involved in updating to 5.x.